### PR TITLE
Add decrement to heal number var

### DIFF
--- a/dnd5e/class-macros/paladin/lay-on-hands.js
+++ b/dnd5e/class-macros/paladin/lay-on-hands.js
@@ -69,9 +69,13 @@ else
                         });
                         await targetActor.update({"data.attributes.hp.value" : targetActor.data.data.attributes.hp.value + number});
                     }
-                     
+                    
+                    //Foundry automatically subtracts a usage when an item is invoked 
+                    //so we need to decrement our healing number by 1 so the usages are updated properly
+                    let newNumber = --number;
+
                     //Update the value under "Features"
-                    featUpdate.data.uses.value = featUpdate.data.uses.value - number;
+                    featUpdate.data.uses.value = featUpdate.data.uses.value - newNumber;
                     await actorData.items.getName(layName).update({ "data.uses.value" : featUpdate.data.uses.value });
 
                     //Update resource counter only if the "Lay on Hands" feature is set to consume it


### PR DESCRIPTION
The var `number` is set to the user input value of the LoH heal amount. This number is then used in a post processing procedure to modify the resource usage values if present.
Since Foundry automatically decrements the attached resources by 1 whenever the ability (item) is used, we must decrement this `number` value by 1 before running post processing in order to accurate reflect remaining usages.
This PR adds such a decrement to the `number` var such that when the usages are updated, the `number` value is reduced by 1 to account for Foundry's automatic usage decrement.