### PR TITLE
Bradfordly bugfix 3 - chaos bolt working

### DIFF
--- a/dnd5e/spell-macros/1st-level/chaos-bolt.js
+++ b/dnd5e/spell-macros/1st-level/chaos-bolt.js
@@ -55,13 +55,18 @@ if (args[0].hitTargets.length > 0) {
   }
   
   // apply the damage of the damage roll as the selected damage type
-  let damageRoll = new Roll(`${args[0].damageRoll.total}`).roll();
+  let damageRoll = await new Roll(`${args[0].damageRoll.total}`).roll();
+  let target = canvas.tokens.get(args[0].targets[0]?._id);
+  
+  //let target = args[0].hitTargets.map((t) => canvas.tokens.get(t._id));
+  //FIXME: why do I not work
+  
   await new MidiQOL.DamageOnlyWorkflow(
     actor,
     token,
     damageRoll.total,
     type,
-    args[0].hitTargets.map((t) => canvas.tokens.get(t._id)),
+    target,
     damageRoll,
     { itemCardId: args[0].itemCardId, useOther: false }
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,717 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@league-of-foundry-developers/foundry-vtt-types": {
+      "version": "9.269.0",
+      "resolved": "https://registry.npmjs.org/@league-of-foundry-developers/foundry-vtt-types/-/foundry-vtt-types-9.269.0.tgz",
+      "integrity": "sha512-M/rz86decPLXet9e6+bi0dm8WSGrT/5MM1QXUMEC7Z8vfKB9Y5D61B1J5laaqb3DdjVDS1kZtQEW3/sPg3EALw==",
+      "dev": true,
+      "requires": {
+        "@pixi/graphics-smooth": "0.0.22",
+        "@types/jquery": "~3.5.9",
+        "@types/simple-peer": "~9.11.1",
+        "handlebars": "4.7.7",
+        "pixi-particles": "4.3.1",
+        "pixi.js": "5.3.11",
+        "socket.io-client": "4.3.2",
+        "tinymce": "5.10.1"
+      }
+    },
+    "@pixi/accessibility": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-5.3.11.tgz",
+      "integrity": "sha512-/oSizd8/g6KUCeAlknMLJ9CRxBt+vWs6e2DrOctMoRupEHcmhICCjIyAp5GF6RZy9T9gNHDOU5p7vo7qEyVxgQ==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.11",
+        "@pixi/display": "5.3.11",
+        "@pixi/utils": "5.3.11"
+      }
+    },
+    "@pixi/app": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-5.3.11.tgz",
+      "integrity": "sha512-ZWrOjGvVl+lK5OJQT3OqSnSRtU2XgQSe/ULg2uGsSWUqMkJews33JIGOjvk4tIsjm4ekSKiPZRMdYFHzPfgEJg==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.11",
+        "@pixi/display": "5.3.11"
+      }
+    },
+    "@pixi/constants": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
+      "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
+      "dev": true
+    },
+    "@pixi/core": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
+      "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
+      "dev": true,
+      "requires": {
+        "@pixi/constants": "5.3.11",
+        "@pixi/math": "5.3.11",
+        "@pixi/runner": "5.3.11",
+        "@pixi/settings": "5.3.11",
+        "@pixi/ticker": "5.3.11",
+        "@pixi/utils": "5.3.11"
+      }
+    },
+    "@pixi/display": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.11.tgz",
+      "integrity": "sha512-rxUyB+RMJ7esEa11HdvzsularDGkYlRqpUn1ju9ZsRuB/Qo9JiVolywvWGSWxN/WnDGfrU2GjDpq9id10nwiag==",
+      "dev": true,
+      "requires": {
+        "@pixi/math": "5.3.11",
+        "@pixi/settings": "5.3.11",
+        "@pixi/utils": "5.3.11"
+      }
+    },
+    "@pixi/extract": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-5.3.11.tgz",
+      "integrity": "sha512-YeBrpIO3E5HUgcdKEldCUqwwDNHm5OBe98YFcdLr5Z0+dQaHnxp9Dm4n75/NojoGb5guYdrV00x+gU2UPHsVdw==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.11",
+        "@pixi/math": "5.3.11",
+        "@pixi/utils": "5.3.11"
+      }
+    },
+    "@pixi/filter-alpha": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-5.3.11.tgz",
+      "integrity": "sha512-HC4PbiEqDWSi3A715av7knFqD3knSXRxPJKG9mWat2CU9eCizSw+JxXp/okMU/fL4ewooiqQWVU2l1wXOHhVFw==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.11"
+      }
+    },
+    "@pixi/filter-blur": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-5.3.11.tgz",
+      "integrity": "sha512-iW5cOMEcDiJidOV95bUfhxdcvwM9JzCoWAd+92gAie8L+ElRSHpu1jxXbKHjo/QczQV1LulOlheyDaJNpaBCDg==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.11",
+        "@pixi/settings": "5.3.11"
+      }
+    },
+    "@pixi/filter-color-matrix": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-5.3.11.tgz",
+      "integrity": "sha512-u9NT4+N1I3XV9ygwsmF8/jIwCLqNCLeFOdM4f73kbw/UmakZZ6i6xjjJMc5YFUpC25qDr1TFlqgdGGGHAPl4ug==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.11"
+      }
+    },
+    "@pixi/filter-displacement": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-5.3.11.tgz",
+      "integrity": "sha512-CTIy7C/L9I1X3VNx4nMzQbMFvznsGk2viQh0dSo8r5NLgmaAdxhkGI0KUpNjLBz30278tzFfNuRe59K1y1kHuw==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.11",
+        "@pixi/math": "5.3.11"
+      }
+    },
+    "@pixi/filter-fxaa": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-5.3.11.tgz",
+      "integrity": "sha512-0ahjui5385e1vRvd7zCc0n5W8ULtNI1uVbDJHP9ueeiF25TKC0GqtZzntNwrQPoU46q8zXdnIGjzMpikbbAasg==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.11"
+      }
+    },
+    "@pixi/filter-noise": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-5.3.11.tgz",
+      "integrity": "sha512-98WC9Nd5u2F03Ned9T3vnbmO/YF1jLSioZ623z9wjqpd5DosZgRtYTSGxjVcXTSfpviIuiJpkyF+X097pbVprg==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.11"
+      }
+    },
+    "@pixi/graphics": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-5.3.11.tgz",
+      "integrity": "sha512-HLu53LV6mRlY0uFSIM2OrCuL7xqXzeJs5d2QfmUJfKJVVZ9sbHDS+6/N/f0tXzvkRPYhSKXvcNPsNn4HmlIE9w==",
+      "dev": true,
+      "requires": {
+        "@pixi/constants": "5.3.11",
+        "@pixi/core": "5.3.11",
+        "@pixi/display": "5.3.11",
+        "@pixi/math": "5.3.11",
+        "@pixi/sprite": "5.3.11",
+        "@pixi/utils": "5.3.11"
+      }
+    },
+    "@pixi/graphics-smooth": {
+      "version": "0.0.22",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics-smooth/-/graphics-smooth-0.0.22.tgz",
+      "integrity": "sha512-qq2u+BJBIDBuuSTc2Xzm1D/8RiiKBdxnVDiMb7Go5v8achnV5ctC6m+rf8Mq0sWm66mbOqu1aq/9efT4A4sPrA==",
+      "dev": true
+    },
+    "@pixi/interaction": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-5.3.11.tgz",
+      "integrity": "sha512-n2K99CYyBcrf8NPxpzmZ5IlJ9TEplsSZfJ/uzMNOEnTObKl4wAhxs51Nb58raH3Ouzwu14YHOpqYrBTEoT1yPA==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.11",
+        "@pixi/display": "5.3.11",
+        "@pixi/math": "5.3.11",
+        "@pixi/ticker": "5.3.11",
+        "@pixi/utils": "5.3.11"
+      }
+    },
+    "@pixi/loaders": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-5.3.11.tgz",
+      "integrity": "sha512-1HAeb/NFXyhNhZWAbVkngsTPBGpjZEPhQflBTrKycRaub7XDSZ8F0fwPltpKKVRWNDT+HBgU/zDNE2fpjzqfYg==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.11",
+        "@pixi/utils": "5.3.11",
+        "resource-loader": "^3.0.1"
+      }
+    },
+    "@pixi/math": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
+      "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
+      "dev": true
+    },
+    "@pixi/mesh": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-5.3.11.tgz",
+      "integrity": "sha512-KWKKksEr0YuUX1uz1FmpIa/Y37b/0pvFUS+87LoyYq0mRtGbKsTY5i3lBPG/taHwN7a2DQAX3JZpw6yhGKoGpA==",
+      "dev": true,
+      "requires": {
+        "@pixi/constants": "5.3.11",
+        "@pixi/core": "5.3.11",
+        "@pixi/display": "5.3.11",
+        "@pixi/math": "5.3.11",
+        "@pixi/settings": "5.3.11",
+        "@pixi/utils": "5.3.11"
+      }
+    },
+    "@pixi/mesh-extras": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-5.3.11.tgz",
+      "integrity": "sha512-1GTCMMUW1xv/72x26cxRysblBXW0wU77TNgqtSIMZ1M6JbleObChklWTvwi9MzQO2vQ3S6Hvcsa5m5EiM2hSPQ==",
+      "dev": true,
+      "requires": {
+        "@pixi/constants": "5.3.11",
+        "@pixi/core": "5.3.11",
+        "@pixi/math": "5.3.11",
+        "@pixi/mesh": "5.3.11",
+        "@pixi/utils": "5.3.11"
+      }
+    },
+    "@pixi/mixin-cache-as-bitmap": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-5.3.11.tgz",
+      "integrity": "sha512-uQUxatGTTD5zfQ0pWdjibVjT+xEEZJ/xZDZtm/GxC7HSHd4jgoJBcTXWVhbhzwpLPVTnD8+sMnRrGlhoKcpTpQ==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.11",
+        "@pixi/display": "5.3.11",
+        "@pixi/math": "5.3.11",
+        "@pixi/settings": "5.3.11",
+        "@pixi/sprite": "5.3.11",
+        "@pixi/utils": "5.3.11"
+      }
+    },
+    "@pixi/mixin-get-child-by-name": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-5.3.11.tgz",
+      "integrity": "sha512-fWFVxWtMYcwJttrgDNmZ4CJrx316p8ToNliC2ILmJZW77me7I4GzJ57gSHQU1xFwdHoOYRC4fnlrZoK5qJ9lDw==",
+      "dev": true,
+      "requires": {
+        "@pixi/display": "5.3.11"
+      }
+    },
+    "@pixi/mixin-get-global-position": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-5.3.11.tgz",
+      "integrity": "sha512-wrS9i+UUodLM5XL2N0Y+XSKiqLRdJV3ltFUWG6+jPT5yoP0HsKtx3sFAzX526RwIYwRzRusbc/quxHfRA4tvgg==",
+      "dev": true,
+      "requires": {
+        "@pixi/display": "5.3.11",
+        "@pixi/math": "5.3.11"
+      }
+    },
+    "@pixi/particles": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/particles/-/particles-5.3.11.tgz",
+      "integrity": "sha512-+mkt/inWXtRrxQc07RZ29uNIDWV1oMsrRBVBIvHgpR92Kn8EjIDRgoSXNu0jiZ18gRKKCBhwsS4dCXGsZRQ/sA==",
+      "dev": true,
+      "requires": {
+        "@pixi/constants": "5.3.11",
+        "@pixi/core": "5.3.11",
+        "@pixi/display": "5.3.11",
+        "@pixi/math": "5.3.11",
+        "@pixi/utils": "5.3.11"
+      }
+    },
+    "@pixi/polyfill": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-5.3.11.tgz",
+      "integrity": "sha512-yQOngcnn+2/L7n6L/g45hCnIDLWdnWmmcCY3UKJrOgbNX+JtLru1RR8AGLifkdsa0R5u48x584YQGqkTAChWVA==",
+      "dev": true,
+      "requires": {
+        "es6-promise-polyfill": "^1.2.0",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "@pixi/prepare": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-5.3.11.tgz",
+      "integrity": "sha512-TvjGeg7xPKjv5NxbM5NXReno9yxUCw/N0HtDEtEFRVeBLN3u0Q/dZsXxL6gIvkHoS09NFW+7AwsYQLZrVbppjA==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.11",
+        "@pixi/display": "5.3.11",
+        "@pixi/graphics": "5.3.11",
+        "@pixi/settings": "5.3.11",
+        "@pixi/text": "5.3.11",
+        "@pixi/ticker": "5.3.11"
+      }
+    },
+    "@pixi/runner": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
+      "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
+      "dev": true
+    },
+    "@pixi/settings": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
+      "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
+      "dev": true,
+      "requires": {
+        "ismobilejs": "^1.1.0"
+      }
+    },
+    "@pixi/sprite": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-5.3.11.tgz",
+      "integrity": "sha512-RM6Sp8kqzsBdX/hDAO25HZywe9VU4uhOronUOQ5Ve0zRe+trdBWQYfi7+5kAcvzqkp25Izc0C+e+4YCqe5OaHQ==",
+      "dev": true,
+      "requires": {
+        "@pixi/constants": "5.3.11",
+        "@pixi/core": "5.3.11",
+        "@pixi/display": "5.3.11",
+        "@pixi/math": "5.3.11",
+        "@pixi/settings": "5.3.11",
+        "@pixi/utils": "5.3.11"
+      }
+    },
+    "@pixi/sprite-animated": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-5.3.11.tgz",
+      "integrity": "sha512-xU1b6H8nJ1l05h7cBGw2DGo4QdLj7xootstZUx2BrTVX5ZENn5mjAGVD0uRpk8yt7Q6Bj7M+PS7ktzAgBW/hmQ==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.11",
+        "@pixi/sprite": "5.3.11",
+        "@pixi/ticker": "5.3.11"
+      }
+    },
+    "@pixi/sprite-tiling": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-5.3.11.tgz",
+      "integrity": "sha512-KUiWsIumjrnp9QKGMe1BqtrV9Hxm91KoaiOlCBk/gw8753iKvuMmH+/Z0RnzeZylJ1sJsdonTWy/IaLi1jnd0g==",
+      "dev": true,
+      "requires": {
+        "@pixi/constants": "5.3.11",
+        "@pixi/core": "5.3.11",
+        "@pixi/display": "5.3.11",
+        "@pixi/math": "5.3.11",
+        "@pixi/sprite": "5.3.11",
+        "@pixi/utils": "5.3.11"
+      }
+    },
+    "@pixi/spritesheet": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-5.3.11.tgz",
+      "integrity": "sha512-Y9Wiwcz/YOuS1v73Ij9KWQakYBzZfldEy3H8T4GPLK+S19/sypntdkNtRZbmR2wWfhJ4axYEB2/Df86aOAU2qA==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.11",
+        "@pixi/loaders": "5.3.11",
+        "@pixi/math": "5.3.11",
+        "@pixi/utils": "5.3.11"
+      }
+    },
+    "@pixi/text": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-5.3.11.tgz",
+      "integrity": "sha512-PmWvJv0wiKyyz3fahnxM19+m8IbF2vpDKIImqb5472WyxRGzKyVBW90xrADf5202tdKMk4b8hqvpof2XULr5PA==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.11",
+        "@pixi/math": "5.3.11",
+        "@pixi/settings": "5.3.11",
+        "@pixi/sprite": "5.3.11",
+        "@pixi/utils": "5.3.11"
+      }
+    },
+    "@pixi/text-bitmap": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-5.3.11.tgz",
+      "integrity": "sha512-Bjc/G4VHaPXc9HJsvyYOm5cNTHdqmX6AgzBAlCfltuMAlnveUgUPuX8D/MJHRRnoVSDHSmCBtnJgTc0y/nIeCw==",
+      "dev": true,
+      "requires": {
+        "@pixi/core": "5.3.11",
+        "@pixi/display": "5.3.11",
+        "@pixi/loaders": "5.3.11",
+        "@pixi/math": "5.3.11",
+        "@pixi/mesh": "5.3.11",
+        "@pixi/settings": "5.3.11",
+        "@pixi/text": "5.3.11",
+        "@pixi/utils": "5.3.11"
+      }
+    },
+    "@pixi/ticker": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
+      "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
+      "dev": true,
+      "requires": {
+        "@pixi/settings": "5.3.11"
+      }
+    },
+    "@pixi/utils": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
+      "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
+      "dev": true,
+      "requires": {
+        "@pixi/constants": "5.3.11",
+        "@pixi/settings": "5.3.11",
+        "earcut": "^2.1.5",
+        "eventemitter3": "^3.1.0",
+        "url": "^0.11.0"
+      }
+    },
+    "@socket.io/component-emitter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.0.0.tgz",
+      "integrity": "sha512-2pTGuibAXJswAPJjaKisthqS/NOK5ypG4LYT6tEAV0S/mxW0zOIvYvGK0V8w8+SHxAm6vRMSjqSalFXeBAqs+Q==",
+      "dev": true
+    },
+    "@types/jquery": {
+      "version": "3.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.14.tgz",
+      "integrity": "sha512-X1gtMRMbziVQkErhTQmSe2jFwwENA/Zr+PprCkF63vFq+Yt5PZ4AlKqgmeNlwgn7dhsXEK888eIW2520EpC+xg==",
+      "dev": true,
+      "requires": {
+        "@types/sizzle": "*"
+      }
+    },
+    "@types/node": {
+      "version": "17.0.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.41.tgz",
+      "integrity": "sha512-xA6drNNeqb5YyV5fO3OAEsnXLfO7uF0whiOfPTz5AeDo8KeZFmODKnvwPymMNO8qE/an8pVY/O50tig2SQCrGw==",
+      "dev": true
+    },
+    "@types/simple-peer": {
+      "version": "9.11.4",
+      "resolved": "https://registry.npmjs.org/@types/simple-peer/-/simple-peer-9.11.4.tgz",
+      "integrity": "sha512-Elje14YvM47k+XEaoyRAeUSvZN7TOLWYL233QCckUaXjT4lRESHnYs0iOK2JoosO5DnCvWu/0Vpl9qnw4KCLWw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/sizzle": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
+      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
+      "dev": true
+    },
+    "backo2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha512-zj6Z6M7Eq+PBZ7PQxl5NT665MvJdAkzp0f60nAJ+sLaSCBPMwVak5ZegFbgVCzFcCJTKFoMizvM5Ld7+JrRJHA==",
+      "dev": true
+    },
+    "debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
+    "earcut": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.3.tgz",
+      "integrity": "sha512-iRDI1QeCQIhMCZk48DRDMVgQSSBDmbzzNhnxIo+pwx3swkfjMh6vh0nWLq1NdvGHLKH6wIrAM3vQWeTj6qeoug==",
+      "dev": true
+    },
+    "engine.io-client": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.0.3.tgz",
+      "integrity": "sha512-IH8ZhDIwiLv0d/wXVzmjfV9Y82hbJIDhCGSVUV8o1kcpDe2I6Y3bZA3ZbJy4Ls7k7IVmcy/qn4k9RKWFhUGf5w==",
+      "dev": true,
+      "requires": {
+        "@socket.io/component-emitter": "~3.0.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.0.0",
+        "has-cors": "1.1.0",
+        "parseqs": "0.0.6",
+        "parseuri": "0.0.6",
+        "ws": "~8.2.3",
+        "xmlhttprequest-ssl": "~2.0.0",
+        "yeast": "0.1.2"
+      }
+    },
+    "engine.io-parser": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.4.tgz",
+      "integrity": "sha512-+nVFp+5z1E3HcToEnO7ZIj3g+3k9389DvWtvJZz0T6/eOCPIyyxehFcedoYrZQrp0LgQbD9pPXhpMBKMd5QURg==",
+      "dev": true
+    },
+    "es6-promise-polyfill": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es6-promise-polyfill/-/es6-promise-polyfill-1.2.0.tgz",
+      "integrity": "sha512-HHb0vydCpoclpd0ySPkRXMmBw80MRt1wM4RBJBlXkux97K7gleabZdsR0gvE1nNPM9mgOZIBTzjjXiPxf4lIqQ==",
+      "dev": true
+    },
+    "eventemitter3": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+      "dev": true
+    },
+    "handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      }
+    },
+    "has-cors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+      "integrity": "sha512-g5VNKdkFuUuVCP9gYfDJHjK2nqdQJ7aDLTnycnc2+RvsOQbuLdF5pm7vuE5J76SEBIQjs4kQY/BWq74JUmjbXA==",
+      "dev": true
+    },
+    "ismobilejs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
+      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
+      "dev": true
+    },
+    "mini-signals": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mini-signals/-/mini-signals-1.2.0.tgz",
+      "integrity": "sha512-alffqMkGCjjTSwvYMVLx+7QeJ6sTuxbXqBkP21my4iWU5+QpTQAJt3h7htA1OKm9F3BpMM0vnu72QIoiJakrLA==",
+      "dev": true
+    },
+    "minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true
+    },
+    "parse-uri": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/parse-uri/-/parse-uri-1.0.7.tgz",
+      "integrity": "sha512-eWuZCMKNlVkXrEoANdXxbmqhu2SQO9jUMCSpdbJDObin0JxISn6e400EWsSRbr/czdKvWKkhZnMKEGUwf/Plmg==",
+      "dev": true
+    },
+    "parseqs": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
+      "integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w==",
+      "dev": true
+    },
+    "parseuri": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
+      "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow==",
+      "dev": true
+    },
+    "pixi-particles": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/pixi-particles/-/pixi-particles-4.3.1.tgz",
+      "integrity": "sha512-XSqDFgYwm/7FRCgP5I2Fc57d98qvb1ql/x4uTjdP4uXDUGgjdO8OW/2A0HVWS1CkOht/1x6dQzsM1oCJAUlaow==",
+      "dev": true
+    },
+    "pixi.js": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-5.3.11.tgz",
+      "integrity": "sha512-/9td6IHDQqG0Po5lyQ5aKDzrnEVD1SvGourI4Nqp0mvNI0Cbm74tMHLjk1V5foqGPAS9pochENr6Y3ft/2cDiQ==",
+      "dev": true,
+      "requires": {
+        "@pixi/accessibility": "5.3.11",
+        "@pixi/app": "5.3.11",
+        "@pixi/constants": "5.3.11",
+        "@pixi/core": "5.3.11",
+        "@pixi/display": "5.3.11",
+        "@pixi/extract": "5.3.11",
+        "@pixi/filter-alpha": "5.3.11",
+        "@pixi/filter-blur": "5.3.11",
+        "@pixi/filter-color-matrix": "5.3.11",
+        "@pixi/filter-displacement": "5.3.11",
+        "@pixi/filter-fxaa": "5.3.11",
+        "@pixi/filter-noise": "5.3.11",
+        "@pixi/graphics": "5.3.11",
+        "@pixi/interaction": "5.3.11",
+        "@pixi/loaders": "5.3.11",
+        "@pixi/math": "5.3.11",
+        "@pixi/mesh": "5.3.11",
+        "@pixi/mesh-extras": "5.3.11",
+        "@pixi/mixin-cache-as-bitmap": "5.3.11",
+        "@pixi/mixin-get-child-by-name": "5.3.11",
+        "@pixi/mixin-get-global-position": "5.3.11",
+        "@pixi/particles": "5.3.11",
+        "@pixi/polyfill": "5.3.11",
+        "@pixi/prepare": "5.3.11",
+        "@pixi/runner": "5.3.11",
+        "@pixi/settings": "5.3.11",
+        "@pixi/sprite": "5.3.11",
+        "@pixi/sprite-animated": "5.3.11",
+        "@pixi/sprite-tiling": "5.3.11",
+        "@pixi/spritesheet": "5.3.11",
+        "@pixi/text": "5.3.11",
+        "@pixi/text-bitmap": "5.3.11",
+        "@pixi/ticker": "5.3.11",
+        "@pixi/utils": "5.3.11"
+      }
+    },
+    "punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
+      "dev": true
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
+      "dev": true
+    },
+    "resource-loader": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/resource-loader/-/resource-loader-3.0.1.tgz",
+      "integrity": "sha512-fBuCRbEHdLCI1eglzQhUv9Rrdcmqkydr1r6uHE2cYHvRBrcLXeSmbE/qI/urFt8rPr/IGxir3BUwM5kUK8XoyA==",
+      "dev": true,
+      "requires": {
+        "mini-signals": "^1.2.0",
+        "parse-uri": "^1.0.0"
+      }
+    },
+    "socket.io-client": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.3.2.tgz",
+      "integrity": "sha512-2B9LqSunN60yV8F7S84CCEEcgbYNfrn7ejIInZtLZ7ppWtiX8rGZAjvdCvbnC8bqo/9RlCNOUsORLyskxSFP1g==",
+      "dev": true,
+      "requires": {
+        "@socket.io/component-emitter": "~3.0.0",
+        "backo2": "~1.0.2",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.0.1",
+        "parseuri": "0.0.6",
+        "socket.io-parser": "~4.1.1"
+      }
+    },
+    "socket.io-parser": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.1.2.tgz",
+      "integrity": "sha512-j3kk71QLJuyQ/hh5F/L2t1goqzdTL0gvDzuhTuNSwihfuFUrcSji0qFZmJJPtG6Rmug153eOPsUizeirf1IIog==",
+      "dev": true,
+      "requires": {
+        "@socket.io/component-emitter": "~3.0.0",
+        "debug": "~4.3.1"
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "tinymce": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.10.1.tgz",
+      "integrity": "sha512-aIsFTYiuESpoYkCgkoojpVtPwrSvYBxp4mMEGsj20CnUruLCWosywkbYHDII+j7KlQZZn3p+xK89f5gT3QyuGw==",
+      "dev": true
+    },
+    "uglify-js": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.0.tgz",
+      "integrity": "sha512-FEikl6bR30n0T3amyBh3LoiBdqHRy/f4H80+My34HOesOKyHfOsxAPAxOoqC0JUnC1amnO0IwkYC3sko51caSw==",
+      "dev": true,
+      "optional": true
+    },
+    "url": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "dev": true,
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "ws": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+      "dev": true
+    },
+    "xmlhttprequest-ssl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
+      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
+      "dev": true
+    },
+    "yeast": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
+      "dev": true
+    }
+  }
+}


### PR DESCRIPTION
Due to changes in the `Roll` type from Midi-QOL, we needed to add an `await` operator when declaring a new roll.

In addition, there is an unknown flaw in the old targeting code used when calling Midi's `DamageOnlyWorkflow`. This was addressed by using standard Foundry token targeting procedure.